### PR TITLE
Fix /me in channels, implement WHOIS and MOTD

### DIFF
--- a/robin-irc.php
+++ b/robin-irc.php
@@ -318,7 +318,7 @@ class Robin_IRC {
     }
 
     public function __call($name, $args) {
-        list($protocol, $msg) = split('_', $name);
+        list($protocol, $msg) = split('_', $name, 2);
         switch (strtoupper($protocol)) {
             case 'IRC':
                 switch (strtoupper($msg)) {
@@ -435,6 +435,9 @@ class Robin_IRC {
                         break;
                     case 'PLEASE_VOTE':
                         $this->out_irc(null, 'NOTICE', self::IRC_CHANNEL, 'Polls are closing soon, please vote');
+                        break;
+                    case 'NO_MATCH':
+                        $this->out_irc(null, 'NOTICE', self::IRC_CHANNEL, 'no compatible room found for matching, we will count votes and check again for a match in 1 minute.');
                         break;
                     case 'SYSTEM_BROADCAST':
                         $this->out_irc(null, 'NOTICE', self::IRC_CHANNEL, $payload['body']);

--- a/robin-irc.php
+++ b/robin-irc.php
@@ -362,7 +362,10 @@ class Robin_IRC {
                                 "\001ACTION" => '',
                                 "\001" => ''
                             ));
-                            $str = '/me '.$str;
+                            $action = 1;
+                        }
+                        else {
+                            $action = 0;
                         }
 
                         if (in_array($channel, $this->prefixes)) {
@@ -373,6 +376,8 @@ class Robin_IRC {
                                 }
                             }
                         }
+                        if ( $action )
+                            $str = '/me '.$str;
 
                         $this->last_message = $str;
 
@@ -408,15 +413,20 @@ class Robin_IRC {
                         ) {
                             // Do nothing if we just sent this message
                         } else {
-                            list($channel, $body) = $this->filter_channel($payload['body']);
+                            $body = $payload['body'];
+                            if (strpos($body, '/me ') === 0) {
+                                $body = substr($body, strlen('/me '));
+                                $action = 1;
+                            }
+                            else {
+                                $action = 0;
+                            }
+                            list($channel, $body) = $this->filter_channel($body);
                             $body = $this->filter_body($body);
                             if ($body) {
-                                if (strpos($body, '/me ') === 0) {
-                                    $body = substr($body, strlen('/me '));
-                                    $this->out_irc($payload['from'], 'PRIVMSG', $channel, "\001ACTION {$body}\001");
-                                } else {
-                                    $this->out_irc($payload['from'], 'PRIVMSG', $channel, $body);
-                                }
+                                if ( $action )
+                                    $body = "\001ACTION {$body}\001";
+                                $this->out_irc($payload['from'], 'PRIVMSG', $channel, $body);
                             }
                         }
                         break;


### PR DESCRIPTION
This is a really cool project!

This pull request includes commits to:
1. Fix the behavior of `/me` in channels, so that it uses, e.g., `/me $` instead of `$ /me`. This seems to match the behavior of other scripts.
2. Add a notice for "no compatible room found for matching"
3. Keep track users and votes, and implement `WHOIS` and `MOTD` commands. (The MOTD now gives the room's count and tally.) Includes associated fixes to parsing/composition of IRC messages.
